### PR TITLE
ccim8x-sbc-pro.coffee: Correct provisioning instructions

### DIFF
--- a/ccimx8x-sbc-pro.coffee
+++ b/ccimx8x-sbc-pro.coffee
@@ -3,11 +3,12 @@ deviceTypesCommon = require '@resin.io/device-types/common'
 
 CC_SD_BOOT = 'Configure the boot microswitches (S2) for SD boot (SW1 OFF and SW2 ON).'
 CC_EMMC_BOOT = 'Configure the boot microswitches (S2) for internal (eMMC) boot (SW1 OFF and SW2 OFF).'
-CC_VARIANT_WARNING = 'Make sure your SBC contains a system-on-module with a 2GB i.MX8X quad B0 system-on-chip. Different module variants are not supported by this device type.'
+CC_VARIANT_WARNING = 'Make sure your SBC contains a system-on-module with a 2GB i.MX8X quad B0 system-on-chip. Different module variants are not supported by this device type and will not boot.'
 
 postProvisioningInstructions = [
         instructions.BOARD_SHUTDOWN
         instructions.REMOVE_INSTALL_MEDIA
+        CC_EMMC_BOOT
         instructions.BOARD_REPOWER
 ]
 
@@ -29,7 +30,7 @@ module.exports =
 		CC_VARIANT_WARNING
 		CC_SD_BOOT
 		instructions.FLASHER_WARNING
-		CC_EMMC_BOOT
+		instructions.CONNECT_AND_BOOT
 	].concat(postProvisioningInstructions)
 
 	gettingStartedLink:

--- a/layers/meta-balena-connectcore/recipes-bsp/u-boot/files/ccimx8x/ccimx8x_common.h-BalenaOS-requires-import-export-env.patch
+++ b/layers/meta-balena-connectcore/recipes-bsp/u-boot/files/ccimx8x/ccimx8x_common.h-BalenaOS-requires-import-export-env.patch
@@ -1,0 +1,26 @@
+From: Alex Gonzalez <alexg@balena.io>
+Date: Sun, 14 Feb 2021 17:28:08 +0100
+Subject: [PATCH] ccimx8x_common.h: BalenaOS requires import/export environment
+ functionality
+
+The ccimx8x BSP undefined the import/export environment functionality
+which is required by BalenaOS.
+
+Signed-off-by: Alex Gonzalez <alexg@balena.io>
+---
+ include/configs/ccimx8x_common.h | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/include/configs/ccimx8x_common.h b/include/configs/ccimx8x_common.h
+index a6db41d948b6..81653eafcbbb 100644
+--- a/include/configs/ccimx8x_common.h
++++ b/include/configs/ccimx8x_common.h
+@@ -207,8 +207,6 @@
+ #define CONFIG_SYS_PBSIZE		(CONFIG_SYS_CBSIZE + \
+ 					sizeof(CONFIG_SYS_PROMPT) + 16)
+ 
+-#undef CONFIG_CMD_EXPORTENV
+-#undef CONFIG_CMD_IMPORTENV
+ #undef CONFIG_CMD_IMLS
+ #undef CONFIG_CMD_CRC32
+ #undef CONFIG_BOOTM_NETBSD

--- a/layers/meta-balena-connectcore/recipes-bsp/u-boot/u-boot-dey_2020.04.bbappend
+++ b/layers/meta-balena-connectcore/recipes-bsp/u-boot/u-boot-dey_2020.04.bbappend
@@ -8,4 +8,5 @@ UBOOT_INITIAL_ENV = ""
 
 SRC_URI_append_ccimx8x = "\
     file://ccimx8x-Use-BalenaOS-partition-table.patch \
+    file://ccimx8x_common.h-BalenaOS-requires-import-export-env.patch \
 "


### PR DESCRIPTION
The provisioning instructions were missing steps.

Changelog-entry: Correct provisioning instructions for ccimx8x-sbc-pro
Signed-off-by: Alex Gonzalez <alexg@balena.io>