### PR TITLE
bluez5: Use bluez5 v5.58 from meta-balena

### DIFF
--- a/layers/meta-balena-connectcore/recipes-connectivity/bluez5/bluez5-%/0003-port-test-discovery-to-python3.patch
+++ b/layers/meta-balena-connectcore/recipes-connectivity/bluez5/bluez5-%/0003-port-test-discovery-to-python3.patch
@@ -15,10 +15,11 @@ index cea77683d..852611c86 100755
 @@ -1,4 +1,4 @@
 -#!/usr/bin/python
 +#!/usr/bin/python3
+ # SPDX-License-Identifier: LGPL-2.1-or-later
 
  from __future__ import absolute_import, print_function, unicode_literals
 
-@@ -18,9 +18,9 @@ def print_compact(address, properties):
+@@ -19,9 +19,9 @@ def print_compact(address, properties):
  	name = ""
  	address = "<unknown>"
 
@@ -30,7 +31,7 @@ index cea77683d..852611c86 100755
  		if (key == "Name"):
  			name = value
  		elif (key == "Address"):
-@@ -41,7 +41,7 @@ def print_normal(address, properties):
+@@ -42,7 +42,7 @@ def print_normal(address, properties):
  	for key in properties.keys():
  		value = properties[key]
  		if type(value) is dbus.String:
@@ -39,7 +40,7 @@ index cea77683d..852611c86 100755
  		if (key == "Class"):
  			print("    %s = 0x%06x" % (key, value))
  		else:
-@@ -61,6 +61,8 @@ def skip_dev(old_dev, new_dev):
+@@ -62,6 +62,8 @@ def skip_dev(old_dev, new_dev):
  	return False
 
  def interfaces_added(path, interfaces):
@@ -48,7 +49,7 @@ index cea77683d..852611c86 100755
  	properties = interfaces["org.bluez.Device1"]
  	if not properties:
  		return
-@@ -70,7 +72,7 @@ def interfaces_added(path, interfaces):
+@@ -71,7 +73,7 @@ def interfaces_added(path, interfaces):
 
  		if compact and skip_dev(dev, properties):
  			return
@@ -57,7 +58,7 @@ index cea77683d..852611c86 100755
  	else:
  		devices[path] = properties
 
-@@ -93,7 +95,7 @@ def properties_changed(interface, changed, invalidated, path):
+@@ -94,7 +96,7 @@ def properties_changed(interface, changed, invalidated, path):
 
  		if compact and skip_dev(dev, changed):
  			return
@@ -66,7 +67,7 @@ index cea77683d..852611c86 100755
  	else:
  		devices[path] = changed
 
-@@ -152,7 +154,7 @@ if __name__ == '__main__':
+@@ -153,7 +155,7 @@ if __name__ == '__main__':
  	om = dbus.Interface(bus.get_object("org.bluez", "/"),
  				"org.freedesktop.DBus.ObjectManager")
  	objects = om.GetManagedObjects()

--- a/layers/meta-balena-connectcore/recipes-connectivity/bluez5/bluez5_%.bbappend
+++ b/layers/meta-balena-connectcore/recipes-connectivity/bluez5/bluez5_%.bbappend
@@ -26,6 +26,8 @@ SRC_URI_append_ccimx8m = " ${QCA65XX_COMMON_PATCHES}"
 
 inherit update-rc.d
 
+DEPENDS += "ell"
+
 do_install_append() {
 	install -d ${D}${sysconfdir}/init.d/
 	install -m 0755 ${WORKDIR}/bluetooth-init ${D}${sysconfdir}/bluetooth-init

--- a/layers/meta-balena-connectcore/recipes-core/ell/ell/0001-pem.c-do-not-use-rawmemchr.patch
+++ b/layers/meta-balena-connectcore/recipes-core/ell/ell/0001-pem.c-do-not-use-rawmemchr.patch
@@ -1,0 +1,27 @@
+From 277e1eca67fcc23cb31be7b826d83a19d9b89bd2 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Tue, 22 Dec 2020 10:30:54 +0000
+Subject: [PATCH] pem.c: do not use rawmemchr()
+
+This is a glibc-only function, and causes build failures with
+alternative libc implementations such as musl.
+
+Upstream-Status: Pending
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+---
+ ell/pem.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ell/pem.c b/ell/pem.c
+index 790f2c2..237ae02 100644
+--- a/ell/pem.c
++++ b/ell/pem.c
+@@ -224,7 +224,7 @@ static uint8_t *pem_load_buffer(const void *buf, size_t buf_len,
+ 
+ 		/* Check that each header line has a key and a colon */
+ 		while (start < end) {
+-			const char *lf = rawmemchr(start, '\n');
++			const char *lf = memchr(start, '\n', end - start);
+ 			const char *colon = memchr(start, ':', lf - start);
+ 
+ 			if (!colon)

--- a/layers/meta-balena-connectcore/recipes-core/ell/ell_0.40.bb
+++ b/layers/meta-balena-connectcore/recipes-core/ell/ell_0.40.bb
@@ -1,0 +1,24 @@
+SUMMARY  = "Embedded Linux Library"
+HOMEPAGE = "https://01.org/ell"
+DESCRIPTION = "The Embedded Linux Library (ELL) provides core, \
+low-level functionality for system daemons. It typically has no \
+dependencies other than the Linux kernel, C standard library, and \
+libdl (for dynamic linking). While ELL is designed to be efficient \
+and compact enough for use on embedded Linux platforms, it is not \
+limited to resource-constrained systems."
+SECTION = "libs"
+LICENSE  = "LGPLv2.1"
+LIC_FILES_CHKSUM = "file://COPYING;md5=fb504b67c50331fc78734fed90fb0e09"
+
+DEPENDS = "dbus"
+
+inherit autotools pkgconfig
+
+SRC_URI = "https://mirrors.edge.kernel.org/pub/linux/libs/${BPN}/${BPN}-${PV}.tar.xz \
+           file://0001-pem.c-do-not-use-rawmemchr.patch \
+           "
+SRC_URI[sha256sum] = "b9bf5c14f2963591ea1372049c05646919a9ed46fcee5cd11ede1022c99ffbbd"
+
+do_configure_prepend () {
+    mkdir -p ${S}/build-aux
+}


### PR DESCRIPTION
Update the ccimx8x board patches originating from meta-digi to bluez v5.58. Also bring ELL from openembedded-core since it is now needed for successful compilation.