### PR TITLE
balena.yml: Add a basic contract

### DIFF
--- a/balena.yml
+++ b/balena.yml
@@ -1,0 +1,2 @@
+type: sw.application
+version: 2.85.10+rev1


### PR DESCRIPTION
This will be used to set the deploy version for the fleets. Note that the
contract version needs to match the meta-balena version and until versionbot
is updated it needs to be manually updated with the meta-balena layer.

Change-type: patch
Changelog-entry: Add a basic contract
Signed-off-by: Alex Gonzalez <alexg@balena.io>