### PR TITLE
balena.yml: Remove name from contract

### DIFF
--- a/balena.yml
+++ b/balena.yml
@@ -1,3 +1,2 @@
-name: ccimx8x-sbc-pro
 type: sw.application
 version: 2.85.16


### PR DESCRIPTION
Device repositories typically build several devices types, so let's keep
this global contract generic.

Changelog-entry: Remove device type name from contract
Signed-off-by: Alex Gonzalez <alexg@balena.io>