### PR TITLE
renovate: Remove automerge for the time being

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,7 +22,6 @@
     {
       "matchManagers": ["git-submodules"],
       "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true,
       "stabilityDays": 0
     }
   ]


### PR DESCRIPTION
It is likely that as compulsory reviews are enforced we will also need
to install `renovate-approve` / `renovate-approve-2` for automerging to
work.

Let's disable it to test the rest of the functionality.

Changelog-entry: Disable renovate automerge
Signed-off-by: Alex Gonzalez <alexg@balena.io>