### PR TITLE
Add renovate-config submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "layers/meta-openembedded"]
 	path = layers/meta-openembedded
 	url = https://github.com/openembedded/meta-openembedded.git
+[submodule ".github"]
+	path = .github
+	url = https://github.com/balena-os/renovate-config.git


### PR DESCRIPTION
This installs a .github/renovate.json file which configures renovate
to update submodule dependencies in this repository.

Changelog-entry: Add renovate-config submodule
Signed-off-by: Alex Gonzalez <alexg@balena.io>