### PR TITLE
Renovate does not support symlinks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,6 +19,3 @@
 [submodule "layers/meta-openembedded"]
 	path = layers/meta-openembedded
 	url = https://github.com/openembedded/meta-openembedded.git
-[submodule "renovate"]
-	path = renovate
-	url = https://github.com/balena-os/renovate-config.git

--- a/renovate.json
+++ b/renovate.json
@@ -1,1 +1,0 @@
-renovate/renovate.json


### PR DESCRIPTION
The renovate.json file cannot be a symlink

Changelog-entry: Remove renovate.json symlinks and submodule
Signed-off-by: Alex Gonzalez <alexg@balena.io>