### PR TITLE
Add renovate-config in .github directory

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "layers/meta-openembedded"]
 	path = layers/meta-openembedded
 	url = https://github.com/openembedded/meta-openembedded.git
+[submodule ".github"]
+	path = .github
+	url = https://github.com/balena-os/renovate-config.git


### PR DESCRIPTION
This allows to keep renovate-config as a submodule.

Changelog-entry: Add renovate-config in .github directory
Signed-off-by: Alex Gonzalez <alexg@balena.io>