### PR TITLE
Remove renovate-config .github submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,6 +19,3 @@
 [submodule "layers/meta-openembedded"]
 	path = layers/meta-openembedded
 	url = https://github.com/openembedded/meta-openembedded.git
-[submodule ".github"]
-	path = .github
-	url = https://github.com/balena-os/renovate-config.git


### PR DESCRIPTION
Modules are not updated when renovate runs so this configuration also
has no effect.

Chanelog-entry: Remove renovate-config submodule
Signed-off-by: Alex Gonzalez <alexg@balena.io>