### PR TITLE
repo.yml: Specify full path in upstream

### DIFF
--- a/repo.yml
+++ b/repo.yml
@@ -2,9 +2,7 @@
 type: 'yocto-based OS image'
 reviewers: 1
 upstream:
-  - repo: 'meta-resin'
-    url: 'http://github.com/resin-os/meta-resin'
-  - repo: 'meta-balena'
+  - repo: 'layers/meta-balena'
     url: 'http://github.com/balena-os/meta-balena'
   - repo: 'balena-yocto-scripts'
     url: 'http://github.com/balena-os/balena-yocto-scripts'


### PR DESCRIPTION
This is required so that versionist can automatically include nested
changelogs from renovate PRs.

Change-type: none
Signed-off-by: Alex Gonzalez <alexg@balena.io>