### PR TITLE
workflows: build_and_deploy: Filter on tags

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -1,9 +1,10 @@
 name: 'Deploy on master merge'
 
 on:
-  pull_request:
-    branches: [ master ]
-    types: [closed]
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+\+?r?e?v?[0-9]?
+      - v20[0-9][0-9].[0-1]?[1470].[0-9]+
 
     # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -14,6 +15,7 @@ jobs:
     outputs:
       tag: ${{ steps.set-tag.outputs.tag }}
       boards: ${{ steps.list-boards.outputs.boards }}
+      status: ${{ join(steps.*.conclusion) }}
     steps:
       - uses: actions/checkout@v3
 
@@ -46,6 +48,7 @@ jobs:
 
   deploy:
     needs: fetch
+    if: contains(needs.fetch.outputs.status, 'success')
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{fromJson(needs.fetch.outputs.boards)}}


### PR DESCRIPTION
Only deploy when a tag for either a rolling or ESR release is created
by versionbot.

Changelog-entry: Filter on tags on build and deploy workflow
Signed-off-by: Alex Gonzalez <alexg@balena.io>