### PR TITLE
workflows: build_and_deploy: Update local tags before fetching latest

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -19,6 +19,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: 'Update local tags'
+        id: update-tags
+        run: git fetch --tags -f
+
       - name: 'Fetch latest tag'
         id: get-latest-tag
         uses: "actions-ecosystem/action-get-latest-tag@v1"


### PR DESCRIPTION
This avoids instances where the local and remote get unsyncronized and
fetching the latest tag fails with 'would clobber existing tag'.

Changelog-entry: Update local tags
Signed-off-by: Alex Gonzalez <alexg@balena.io>