### PR TITLE
workflows: build_and_deploy: Rename to match the action

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -1,4 +1,4 @@
-name: 'Deploy on master merge'
+name: 'Deploy on master release tag'
 
 on:
   push:


### PR DESCRIPTION
The workflow is now deploying on master release tag and not PR merge.

Chanelog-entry: Rename workflow
Signed-off-by: Alex Gonzalez <alexg@balena.io>