### PR TITLE
workflow: build and deploy: Change name to deploy on release tag

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -1,4 +1,4 @@
-name: 'Deploy on master release tag'
+name: 'Deploy on release tag'
 
 on:
   push:


### PR DESCRIPTION
Tags can happen on any branch, not just on master, for example for ESR.

Changelog-entry: Rename deploy workflow
Signed-off-by: Alex Gonzalez <alexg@balena.io>