### PR TITLE
workflows: build_and_deploy: Only run on device repositories

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -19,6 +19,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: 'Only run for device repositories'
+        id: assert-device-repository
+        run: |
+          if [ -f "$(pwd)/repo.yml" ]; then
+            if grep -q "yocto-based OS image" repo.yml; then
+              exit 0
+            fi
+          fi
+          exit 1
+
       - name: 'Update local tags'
         id: update-tags
         run: git fetch --tags -f


### PR DESCRIPTION
Changelog-entry: Only run deploy workflow on device repositories
Signed-off-by: Alex Gonzalez <alexg@balena.io>