### PR TITLE
workflows: build and deploy: Remove final argument

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -14,5 +14,4 @@ jobs:
     uses: balena-os/github-workflows/.github/workflows/build_and_deploy.yml@v0.0.9
     with:
       deployTo: "production"
-      final: "no"
     secrets: inherit


### PR DESCRIPTION
The final argument is now filled up dynamically.

Changelog-entry: Remove final argument from build and deploy workflow
Signed-off-by: Alex Gonzalez <alexg@balena.io>